### PR TITLE
fix: use hoisted node-linker to avoid broken pnpm global store symlinks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted


### PR DESCRIPTION
When pnpm installs deps with the default symlink strategy, `node_modules` entries are symlinks into the global pnpm store. Running `pnpm link -g` for other packages can prune those store entries, breaking the extension at load time with:

```
Cannot find module 'web-tree-sitter'
```

Using `node-linker=hoisted` in `.npmrc` produces a flat `node_modules` with real files, making the install resilient to global store changes.