### PR TITLE
fix: use fileURLToPath instead of .pathname for Windows compatibility

### DIFF
--- a/src/tree-sitter/parser-manager.ts
+++ b/src/tree-sitter/parser-manager.ts
@@ -6,6 +6,7 @@
  */
 
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import Parser from "web-tree-sitter";
 import { getLanguageIdFromPath } from "../shared/language-map.js";
 
@@ -56,7 +57,7 @@ export class TreeSitterManager {
   constructor() {
     // Resolve the grammars directory from tree-sitter-wasms package
     this.grammarsDir = resolve(
-      new URL(".", import.meta.url).pathname,
+      fileURLToPath(new URL(".", import.meta.url)),
       "../../node_modules/tree-sitter-wasms/out"
     );
   }
@@ -72,7 +73,7 @@ export class TreeSitterManager {
       locateFile: (scriptName: string) => {
         // web-tree-sitter needs its own .wasm file
         return resolve(
-          new URL(".", import.meta.url).pathname,
+          fileURLToPath(new URL(".", import.meta.url)),
           "../../node_modules/web-tree-sitter",
           scriptName
         );

--- a/test-tree-sitter.ts
+++ b/test-tree-sitter.ts
@@ -8,8 +8,9 @@
 import { TreeSitterManager } from "./src/tree-sitter/parser-manager.js";
 import { extractSymbols, getNodeAtPosition, findDefinition, getSyntaxErrors, getSignatureText, getEnclosingDeclaration } from "./src/tree-sitter/symbol-extractor.js";
 import { WorkspaceIndex } from "./src/tree-sitter/workspace-index.js";
-import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 let passed = 0;
 let failed = 0;
@@ -356,6 +357,28 @@ export function newHelper(): void {}
   assert(tree3 !== tree1, "different content returns new tree");
   mgr.invalidate("/tmp/cache-test.ts");
   assert(mgr.getCachedTree("/tmp/cache-test.ts") === null, "invalidate clears cache");
+
+
+  // ── 12. Windows path regression (fileURLToPath vs .pathname) ──
+  // On Windows, import.meta.url is 'file:///C:/path/...'.
+  // Using .pathname gives '/C:/path/...' — path.resolve() treats the leading
+  // slash as 'root of current drive', so if CWD is on E:\ you get E:\C:\...
+  // Using fileURLToPath() correctly produces 'C:\path\...' on Windows.
+  console.log("\n🪟 Windows path regression (fileURLToPath vs .pathname)");
+
+  const moduleDir = fileURLToPath(new URL(".", import.meta.url));
+  const wasmPath = resolve(moduleDir, "node_modules/web-tree-sitter/tree-sitter.wasm");
+
+  assert(existsSync(wasmPath), `wasm resolves to a real file: ${wasmPath}`);
+
+  // Detect drive-doubling: a sign that .pathname was used on Windows.
+  // e.g. 'E:\\C:\\Users\\...' when CWD drive != module drive.
+  const hasDriveDoubling = /[A-Za-z]:\\[A-Za-z]:\\/.test(wasmPath);
+  assert(!hasDriveDoubling, `path has no doubled drive letter: ${wasmPath}`);
+
+  // Also verify the grammar dir resolves cleanly to real .wasm grammar files.
+  const grammarPath = resolve(moduleDir, "node_modules/tree-sitter-wasms/out/tree-sitter-typescript.wasm");
+  assert(existsSync(grammarPath), `grammar wasm resolves to a real file: ${grammarPath}`);
 
   // ── Cleanup ──
   try { rmSync(testDir, { recursive: true }); } catch {}


### PR DESCRIPTION
## Problem

On Windows, `new URL('.', import.meta.url).pathname` returns a URL-style path like `/C:/Users/...` — with a leading slash but no drive letter. When passed to `path.resolve()`, the leading slash is treated as _root of current drive_. So if the process CWD is on a different drive than where Node modules live (e.g. project on `E:\), the result is a broken path like `E:\C:\Users\...` that doesn't exist.

This caused the extension to crash on startup with:
```
failed to asynchronously prepare wasm: Error: ENOENT: no such file or directory,
open 'E:\C:\Users\...\pi-lsp-extension\node_modules\web-tree-sitter\tree-sitter.wasm'
```

## Fix

Replace `.pathname` with `fileURLToPath()` from `node:url`, which correctly converts `file:///C:/Users/...` to `C:\Users\...` on Windows — a proper absolute path with a drive letter that `path.resolve()` handles correctly.

Two call sites in `TreeSitterManager`:
- Constructor: `grammarsDir` resolution (grammar `.wasm` files)
- `init()`: `locateFile` callback (core `tree-sitter.wasm` runtime)

## Test

Added section 12 to `test-tree-sitter.ts` that:
- Verifies `tree-sitter.wasm` exists at the `fileURLToPath`-resolved path
- Asserts no drive-doubling pattern (e.g. `E:\C:\`) in the resolved path
- Verifies a grammar `.wasm` file also resolves correctly