### PR TITLE
fix: guard against EPIPE crashes when LSP server exits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,19 @@ function loadProjectConfig(dir: string): ProjectLspConfig | null {
 }
 
 export default function lspExtension(pi: ExtensionAPI) {
+  // Prevent EPIPE errors from LSP server exits from crashing the host process.
+  // When an LSP server exits unexpectedly, in-flight writes to its stdin pipe
+  // can produce EPIPE errors that escape all connection-level error handlers.
+  const origListeners = process.listeners("uncaughtException");
+  process.on("uncaughtException", (err: any) => {
+    if (err?.code === "EPIPE") return; // swallow — LSP server exited, harmless
+    // Re-throw for other handlers
+    for (const listener of origListeners) (listener as any)(err);
+    if (origListeners.length === 0) {
+      console.error("[LSP] Uncaught exception:", err);
+    }
+  });
+
   let manager: LspManager | null = null;
   let fileSync: FileSync | null = null;
   let treeSitter: TreeSitterManager | null = null;

--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -209,14 +209,30 @@ export class LspClient {
     const stdin = this.process.stdin!;
     const originalWrite = stdin.write;
     stdin.write = function (this: typeof stdin, ...args: any[]): boolean {
-      if (this.destroyed) {
+      if (this.destroyed || this.writableEnded || this.writableFinished) {
         // Call the callback (last arg) so the Promise resolves instead of rejecting
         const cb = args[args.length - 1];
         if (typeof cb === "function") process.nextTick(cb);
         return false;
       }
-      return originalWrite.apply(this, args as any);
+      try {
+        return originalWrite.apply(this, args as any);
+      } catch (err: any) {
+        // Catch EPIPE synchronously — process exited between our check and the write
+        if (err?.code === "EPIPE" || err?.code === "ERR_STREAM_DESTROYED") {
+          const cb = args[args.length - 1];
+          if (typeof cb === "function") process.nextTick(cb);
+          return false;
+        }
+        throw err;
+      }
     } as any;
+
+    // Catch EPIPE on the stdin stream itself to prevent unhandled error events
+    stdin.on("error", (err: any) => {
+      if (err?.code === "EPIPE") return; // expected when server exits
+      console.error(`[LSP ${this.languageId}] stdin error: ${err.message}`);
+    });
 
     this.process.on("error", (err) => {
       console.error(`[LSP ${this.languageId}] Process error: ${err.message}`);


### PR DESCRIPTION
Three layers of defense against LSP server exits crashing the host process:

- **Global uncaughtException handler** (index.ts): swallows EPIPE errors from dead server pipes that escape connection-level handlers
- **Expanded stdin.write guard** (lsp-client.ts): checks `writableEnded`/`writableFinished` in addition to `destroyed`, plus try/catch for EPIPE between the check and the actual write
- **stdin error listener** (lsp-client.ts): catches EPIPE at the stream level to prevent unhandled error events

Without these, when an LSP server exits unexpectedly, in-flight writes to its stdin pipe produce EPIPE errors that crash the host process.