### PR TITLE
fix: drop .js suffix on vscode-languageserver-protocol/node subpath import

### DIFF
--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -19,7 +19,7 @@ import {
   SocketMessageReader,
   SocketMessageWriter,
   type MessageConnection,
-} from "vscode-languageserver-protocol/node.js";
+} from "vscode-languageserver-protocol/node";
 import type {
   InitializeParams,
   InitializeResult,


### PR DESCRIPTION
## Problem

`src/lsp-client.ts` imports from `vscode-languageserver-protocol/node.js`, but that package's `exports` map only defines the `./node` subpath (no `./node.js`):

```json
"./node": { "types": "./lib/node/main.d.ts", "node": "./lib/node/main.js" }
```

Under Node's strict subpath-`exports` enforcement, importing `./node.js` fails and aborts loading the extension:

```
Failed to load extension: Package subpath './node.js' is not defined by "exports"
in .../vscode-languageserver-protocol/package.json
```

Reproduced on Node v25.2.1 with `vscode-languageserver-protocol@3.18.0`. In a host that loads multiple extensions (e.g. pi), this one failure aborts loading of the others too.

## Fix

Drop the `.js` suffix so the import resolves via the package's declared `./node` export:

```diff
-} from "vscode-languageserver-protocol/node.js";
+} from "vscode-languageserver-protocol/node";
```

Verified with Node's own resolver:

```
import.meta.resolve('vscode-languageserver-protocol/node')    -> lib/node/main.js   ✓
import.meta.resolve('vscode-languageserver-protocol/node.js') -> ERR_PACKAGE_PATH_NOT_EXPORTED  ✗
```

## Compatibility

No behavior change. `./node` is the subpath the package's `exports` map declares, so it resolves on every Node that supports subpath exports (12.17+/14+). There is no physical `node.js` at the package root, so no environment relied on the `.js` form resolving via filesystem fallback — the suffix only worked under lax bundler resolvers that ignore `exports`.